### PR TITLE
Add <algorithm> header to fix compilation issue on Arch Linux

### DIFF
--- a/src/core/application.inl
+++ b/src/core/application.inl
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <algorithm>
 #include <core/application.h>
 
 #define CHECK_WINDOW_PTR(win) \

--- a/src/core/graphics.inl
+++ b/src/core/graphics.inl
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <algorithm>
 #include <core/graphics.h>
 
 namespace mlx

--- a/src/renderer/command/vk_cmd_buffer.h
+++ b/src/renderer/command/vk_cmd_buffer.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   vk_cmd_buffer.h                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: maldavid <kbz_8.dev@akel-engine.com>       +#+  +:+       +#+        */
+/*   By: bonsthie <bonsthie@42angouleme.fr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/06 18:25:42 by maldavid          #+#    #+#             */
-/*   Updated: 2024/01/07 01:25:50 by maldavid         ###   ########.fr       */
+/*   Updated: 2024/08/08 17:46:00 by bonsthie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@
 #include <volk.h>
 #include <renderer/core/vk_fence.h>
 #include <vector>
+#include <algorithm>
 
 namespace mlx
 {


### PR DESCRIPTION
The code was failing to compile on Arch Linux due to missing definitions from the <algorithm> header. Including this header resolves the issue, ensuring compatibility across different environments.